### PR TITLE
Support latest version of web3

### DIFF
--- a/contracts/EthPrice.sol
+++ b/contracts/EthPrice.sol
@@ -12,10 +12,10 @@ contract EthPrice is usingProvable {
     constructor()
         public
     {
-        fetchEthPriveViaProvable();
+        fetchEthPriceViaProvable();
     }
 
-    function fetchEthPriveViaProvable()
+    function fetchEthPriceViaProvable()
         public
         payable
     {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "url": "git+https://github.com/provable-things/truffle-starter.git"
   },
   "dependencies": {
-    "ethereum-bridge": "0.6.1",
-    "web3": "1.0.0-beta.36"
+    "ethereum-bridge": "^0.6.2",
+    "web3": "^1.0.0-beta.55"
   },
   "scripts": {
     "bridge": "./node_modules/.bin/ethereum-bridge -a 9 -H 127.0.0.1 -p 9545 --dev"

--- a/test/util/Events.js
+++ b/test/util/Events.js
@@ -1,0 +1,7 @@
+module.exports.waitForEvent = (event, from = 0, to = 'latest') =>
+  new Promise (
+      (resolve,reject) => event(
+          {fromBlock: from, toBlock: to},
+          (e, ev) => e ? reject(e) : resolve(ev)
+      )
+  );

--- a/test/util/Exceptions.js
+++ b/test/util/Exceptions.js
@@ -1,0 +1,20 @@
+async function tryCatch(promise, message) {
+    try {
+        await promise;
+        throw null;
+    }
+    catch (error) {
+        assert(error, "Expected an error but did not get one");
+        assert(error.message.includes(message));
+    }
+}
+
+module.exports = {
+    catchRevert            : async function(promise) {await tryCatch(promise, "revert"             );},
+    catchOutOfGas          : async function(promise) {await tryCatch(promise, "out of gas"         );},
+    catchInvalidJump       : async function(promise) {await tryCatch(promise, "invalid JUMP"       );},
+    catchInvalidOpcode     : async function(promise) {await tryCatch(promise, "invalid opcode"     );},
+    catchStackOverflow     : async function(promise) {await tryCatch(promise, "stack overflow"     );},
+    catchStackUnderflow    : async function(promise) {await tryCatch(promise, "stack underflow"    );},
+    catchStaticStateChange : async function(promise) {await tryCatch(promise, "static state change");},
+};


### PR DESCRIPTION
This PR fixes #8 

* In contracts/EthPrice.sol
  - refactor/renamed fetchEthPriveViaProvable to fetchEthPriceViaProvable (mispelling)

* Refactor/moved test/util.js to test/util/Events.js

* Added test/util/Exceptions.js for absracting the handling of revert or other types of transaction failures

* In test/eth-price-tests.js,
  - import waitForEvent from util/Events
  - import exceptions from util/Exceptions
  - in test 'Should set ETH price correctly in contract', convert return of call with toNumber()
  - in test 'Should revert on second query attempt due to lack of funds',
    - rewrite try/catch to use exceptions.catchRevert
    - refactored fetchEthPriveViaProvable to fetchEthPriceViaProvable (mispelling)
  - In test 'Should succeed on a second query attempt when sending funds',
    - refactored fetchEthPriveViaProvable to fetchEthPriceViaProvable (mispelling)
    - dont' await call to fetchEthPriceViaProvable
    - instead, await waitForEvent to get the event data then assert on its description

 * In package.json,
   - changed ethereum-bridge version selector to "^0.6.2"
   - changed web3 version selector to "^1.0.0-beta.55"

**Tests passing with `"web3": "^1.0.0-beta.55"`**
![Screen Shot 2019-07-17 at 5 25 24 PM](https://user-images.githubusercontent.com/871933/61413983-d73d1a00-a8ba-11e9-8a46-7581ecd34d7c.png)
