### PR TITLE
chore(packages): pin web3 version again...

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "ethereum-bridge": "^0.6.2",
-    "web3": "^1.0.0-beta.55"
+    "web3": "1.0.0-beta.55"
   },
   "scripts": {
     "bridge": "./node_modules/.bin/ethereum-bridge -a 9 -H 127.0.0.1 -p 9545 --dev"


### PR DESCRIPTION
...since the newest is now clashing with Truffle's own w3 dep.